### PR TITLE
changed signature for A3DProjectPointCloud2 API, third arg should be IntPtr

### DIFF
--- a/2022_U1/src/Direct/API.cs
+++ b/2022_U1/src/Direct/API.cs
@@ -1637,7 +1637,7 @@ namespace TS3D.Exchange.Direct
         public static PFA3DProjectPointCloudManagerCreateFromModelFile A3DProjectPointCloudManagerCreateFromModelFile = null;
         public delegate A3DStatus PFA3DProjectPointCloudManagerDelete(IntPtr pManager);
         public static PFA3DProjectPointCloudManagerDelete A3DProjectPointCloudManagerDelete = null;
-        public delegate A3DStatus PFA3DProjectPointCloud2(IntPtr pManager, uint uPointCloudSize, ref A3DVector3dData pPointCloudToProject, bool bUseExactComputation, uint uNbThreads, double dInsidePointEdgeTolerance, IntPtr ppProjectedPointCloud);
+        public delegate A3DStatus PFA3DProjectPointCloud2(IntPtr pManager, uint uPointCloudSize, IntPtr pPointCloudToProject, bool bUseExactComputation, uint uNbThreads, double dInsidePointEdgeTolerance, IntPtr ppProjectedPointCloud);
         public static PFA3DProjectPointCloud2 A3DProjectPointCloud2 = null;
         public delegate A3DStatus PFA3DComputePlanarSectionOnRepresentationItem(IntPtr pRiBrepModel, ref A3DPlanarSectionData psSectionParametersData, out IntPtr ppRISectionResults);
         public static PFA3DComputePlanarSectionOnRepresentationItem A3DComputePlanarSectionOnRepresentationItem = null;


### PR DESCRIPTION
The Exchange C API defines the third arg to A3DProjectPointCloud2 as a pointer to A3DVector3dData.  You pass a pointer to a buffer which contains a list of these structs, one for each input point.

The ExchangeSharp wrapper incorrectly marshals this as a ref to this struct.  This corrects that by just marshalling as an IntPtr which allows you to create the buffer, fill it in and then pass the buffer in.

You'll want to update the generator code to account for this and update it in the other versions.  I only updated the output for the version we're currently using (2022 U1).